### PR TITLE
Add private worker pools to resources

### DIFF
--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -118,6 +118,11 @@
 | gke_clusters.master_ipv4_cidr_block | IP range in CIDR notation to use for the hosted master network. | string | false | - | - |
 | gke_clusters.name | Name of GKE cluster. | string | true | - | - |
 | gke_clusters.network | Name of the GKE cluster's network. | string | false | - | - |
+| gke_clusters.network_peering_routes_config | GKE clustes network peering's route settings. See <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering_routes_config>. | object | false | - | - |
+| gke_clusters.network_peering_routes_config.export_custom_routes | Whether to export the custom routes to the peer network. | boolean | false | - | - |
+| gke_clusters.network_peering_routes_config.import_custom_routes | Whether to import the custom routes to the peer network. | boolean | false | - | - |
+| gke_clusters.network_peering_routes_config.network | The name of the primary network for the peering. | string | false | - | - |
+| gke_clusters.network_peering_routes_config.project | The ID of the project in which the resource belongs. | string | false | - | - |
 | gke_clusters.network_project_id | Name of network project. If unset, the current project will be used. | string | false | - | ^[a-z][a-z0-9\-]{4,28}[a-z0-9]$ |
 | gke_clusters.node_pools | List of maps containing node pools. For supported fields, see the [module example](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/examples/node_pool_update_variant). | array(object) | false | - | - |
 | gke_clusters.resource_name | Override for Terraform resource name. If unset, defaults to normalized name. Normalization will make all characters alphanumeric with underscores. | string | false | - | - |

--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -208,6 +208,7 @@
 | private_worker_pools.create_gke_vpn_connection | HA VPN connection between the private worker pool vpc and the gke network vpc. See <https://registry.terraform.io/modules/terraform-google-modules/vpn/google/latest/submodules/vpn_ha>. | object | false | - | - |
 | private_worker_pools.create_gke_vpn_connection.gke_control_plane_range | The CIDR of the gke cluster control plane range. E.g. 192.168.0.0/28. | string | true | - | - |
 | private_worker_pools.create_gke_vpn_connection.gke_name | Name of the GKE cluster the worker pool can access. | string | true | - | - |
+| private_worker_pools.create_gke_vpn_connection.gke_network | Name of the bastion host's subnet. | string | true | - | - |
 | private_worker_pools.name | Name of private worker pool. | string | true | - | - |
 | private_worker_pools.pool_address | IP address of the worker pool IP range. | string | true | - | - |
 | private_worker_pools.pool_prefix_length | The prefix length of the worker pool IP range. | integer | true | - | - |

--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -205,10 +205,10 @@
 | kubernetes_service_accounts.provider | The alias of the kubernetes provider. This field allows the resource to authenticate with the intended cluster. See <https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs> | string | false | - | - |
 | private_worker_pools | Cloudbuild private worker pool config.<br><br>This creates a worker pool with a dedicated computer network subnet and creates a peering connection with the subnet.  Must be created in the networks project used in the GKE cluster. | array(object) | false | - | - |
 | private_worker_pools.compute_region | Region to create worker pool in. Can be defined in global data block. | string | false | - | - |
-| private_worker_pools.create_gke_vpn_connection | HA VPN connection between the private worker pool vpc and the gke network vpc. See <https://registry.terraform.io/modules/terraform-google-modules/vpn/google/latest/submodules/vpn_ha>. | object | false | - | - |
-| private_worker_pools.create_gke_vpn_connection.gke_control_plane_range | The CIDR of the gke cluster control plane range. E.g. 192.168.0.0/28. | string | true | - | - |
-| private_worker_pools.create_gke_vpn_connection.gke_name | Name of the GKE cluster the worker pool can access. | string | true | - | - |
-| private_worker_pools.create_gke_vpn_connection.gke_network | Name of the bastion host's subnet. | string | true | - | - |
+| private_worker_pools.gke_vpn_connection | HA VPN connection between the private worker pool vpc and the gke network vpc. See <https://registry.terraform.io/modules/terraform-google-modules/vpn/google/latest/submodules/vpn_ha>. | object | false | - | - |
+| private_worker_pools.gke_vpn_connection.gke_control_plane_range | The CIDR of the gke cluster control plane range. E.g. 192.168.0.0/28. | string | true | - | - |
+| private_worker_pools.gke_vpn_connection.gke_name | Name of the GKE cluster the worker pool can access. | string | true | - | - |
+| private_worker_pools.gke_vpn_connection.gke_network | Name of the bastion host's subnet. | string | true | - | - |
 | private_worker_pools.name | Name of private worker pool. | string | true | - | - |
 | private_worker_pools.pool_address | IP address of the worker pool IP range. | string | true | - | - |
 | private_worker_pools.pool_prefix_length | The prefix length of the worker pool IP range. | integer | true | - | - |

--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -203,6 +203,14 @@
 | kubernetes_service_accounts.name | Name of the KSA. | string | true | - | - |
 | kubernetes_service_accounts.namespace | Namespace to where the KSA will be created. | string | true | - | - |
 | kubernetes_service_accounts.provider | The alias of the kubernetes provider. This field allows the resource to authenticate with the intended cluster. See <https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs> | string | false | - | - |
+| private_worker_pools | Cloudbuild private worker pool config.<br><br>This creates a worker pool with a dedicated computer network subnet and creates a peering connection with the subnet.  Must be created in the networks project used in the GKE cluster. | array(object) | false | - | - |
+| private_worker_pools.compute_region | Region to create worker pool in. Can be defined in global data block. | string | false | - | - |
+| private_worker_pools.create_gke_vpn_connection | HA VPN connection between the private worker pool vpc and the gke network vpc. See <https://registry.terraform.io/modules/terraform-google-modules/vpn/google/latest/submodules/vpn_ha>. | object | false | - | - |
+| private_worker_pools.create_gke_vpn_connection.gke_control_plane_range | The CIDR of the gke cluster control plane range. E.g. 192.168.0.0/28. | string | true | - | - |
+| private_worker_pools.create_gke_vpn_connection.gke_name | Name of the GKE cluster the worker pool can access. | string | true | - | - |
+| private_worker_pools.name | Name of private worker pool. | string | true | - | - |
+| private_worker_pools.pool_address | IP address of the worker pool IP range. | string | true | - | - |
+| private_worker_pools.pool_prefix_length | The prefix length of the worker pool IP range. | integer | true | - | - |
 | pubsub_topics | [Module](https://github.com/terraform-google-modules/terraform-google-pubsub) | array() | false | - | - |
 | pubsub_topics.labels | Labels to set on the topic. | object | false | - | - |
 | pubsub_topics.labels.*pattern* | - | string | false | - | .+ |

--- a/examples/tfengine/generated/team/cicd/triggers.tf
+++ b/examples/tfengine/generated/team/cicd/triggers.tf
@@ -36,7 +36,7 @@ resource "google_cloudbuild_trigger" "validate_prod" {
   substitutions = {
     _TERRAFORM_ROOT = "terraform"
     _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members kubernetes"
-    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/worker-pool"
+    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/cicd-pool"
   }
 
   depends_on = [
@@ -66,7 +66,7 @@ resource "google_cloudbuild_trigger" "plan_prod" {
   substitutions = {
     _TERRAFORM_ROOT = "terraform"
     _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members kubernetes"
-    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/worker-pool"
+    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/cicd-pool"
   }
 
   depends_on = [
@@ -97,7 +97,7 @@ resource "google_cloudbuild_trigger" "apply_prod" {
   substitutions = {
     _TERRAFORM_ROOT = "terraform"
     _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members kubernetes"
-    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/worker-pool"
+    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/cicd-pool"
   }
 
   depends_on = [

--- a/examples/tfengine/generated/team/cicd/triggers.tf
+++ b/examples/tfengine/generated/team/cicd/triggers.tf
@@ -35,8 +35,8 @@ resource "google_cloudbuild_trigger" "validate_prod" {
 
   substitutions = {
     _TERRAFORM_ROOT = "terraform"
-    _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members"
-    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/cicd-pool"
+    _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members kubernetes"
+    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/worker-pool"
   }
 
   depends_on = [
@@ -65,8 +65,8 @@ resource "google_cloudbuild_trigger" "plan_prod" {
 
   substitutions = {
     _TERRAFORM_ROOT = "terraform"
-    _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members"
-    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/cicd-pool"
+    _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members kubernetes"
+    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/worker-pool"
   }
 
   depends_on = [
@@ -96,8 +96,8 @@ resource "google_cloudbuild_trigger" "apply_prod" {
 
   substitutions = {
     _TERRAFORM_ROOT = "terraform"
-    _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members"
-    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/cicd-pool"
+    _MANAGED_DIRS   = "project_secrets project_networks project_apps project_data additional_iam_members kubernetes"
+    _WORKER_POOL    = "projects/example-prod-devops/locations/us-east1/workerPools/worker-pool"
   }
 
   depends_on = [

--- a/examples/tfengine/generated/team/project_apps/main.tf
+++ b/examples/tfengine/generated/team/project_apps/main.tf
@@ -240,6 +240,13 @@ module "gke_cluster" {
     module.project
   ]
 }
+resource "google_compute_network_peering_routes_config" "peering_gke_cluster" {
+  network              = "network"
+  project              = "example-prod-networks"
+  import_custom_routes = false
+  export_custom_routes = true
+  peering              = module.gke_cluster.peering_name
+}
 
 module "project_iam_members" {
   source  = "terraform-google-modules/iam/google//modules/projects_iam"

--- a/examples/tfengine/generated/team/project_apps/main.tf
+++ b/examples/tfengine/generated/team/project_apps/main.tf
@@ -217,11 +217,17 @@ module "gke_cluster" {
   regional           = true
   network_project_id = "example-prod-networks"
 
-  network                 = "network"
-  subnetwork              = "gke-subnet"
-  ip_range_pods           = "pods-range"
-  ip_range_services       = "services-range"
-  master_ipv4_cidr_block  = "192.168.0.0/28"
+  network                = "network"
+  subnetwork             = "gke-subnet"
+  ip_range_pods          = "pods-range"
+  ip_range_services      = "services-range"
+  master_ipv4_cidr_block = "172.16.0.0/28"
+  master_authorized_networks = [
+    {
+      cidr_block   = "192.168.0.0/16"
+      display_name = "cloudbuild"
+    },
+  ]
   skip_provisioners       = true
   enable_private_endpoint = false
   release_channel         = "STABLE"

--- a/examples/tfengine/generated/team/project_networks/main.tf
+++ b/examples/tfengine/generated/team/project_networks/main.tf
@@ -287,7 +287,7 @@ module "worker_pool_vpn_ha_2" {
   version          = "~> 1.5.0"
   project_id       = module.project.project_id
   region           = "us-central1"
-  network          = module.123.network_self_link
+  network          = module.network.network.network.self_link
   name             = "gke-cluster-net-to-worker-pool-net"
   router_asn       = 64513
   peer_gcp_gateway = module.worker_pool_vpn_ha_1.self_link

--- a/examples/tfengine/modules/foundation.hcl
+++ b/examples/tfengine/modules/foundation.hcl
@@ -134,6 +134,7 @@ template "cicd" {
           plan     = {}
           apply    = { run_on_push = false } # Do not auto run on push to branch
         }
+        # Kubernetes intentionally left out as it cannot be deployed by CICD.
         managed_dirs = [
           "project_secrets",
           "project_networks",
@@ -145,7 +146,7 @@ template "cicd" {
         worker_pool = {
           project  = "{{.prefix}}-{{.env}}-devops"
           location = "us-east1"
-          name     = "worker-pool"
+          name     = "cicd-pool"
         }
       }
     ]

--- a/examples/tfengine/modules/foundation.hcl
+++ b/examples/tfengine/modules/foundation.hcl
@@ -134,18 +134,18 @@ template "cicd" {
           plan     = {}
           apply    = { run_on_push = false } # Do not auto run on push to branch
         }
-        # Kubernetes intentionally left out as it cannot be deployed by CICD.
         managed_dirs = [
           "project_secrets",
           "project_networks",
           "project_apps",
           "project_data",
           "additional_iam_members",
+          "kubernetes"
         ]
         worker_pool = {
           project  = "{{.prefix}}-{{.env}}-devops"
           location = "us-east1"
-          name     = "cicd-pool"
+          name     = "worker-pool"
         }
       }
     ]

--- a/examples/tfengine/modules/team.hcl
+++ b/examples/tfengine/modules/team.hcl
@@ -156,7 +156,7 @@ EOF
         name                      = "worker-pool"
         pool_address              = "192.168.0.0"
         pool_prefix_length        = 16
-        create_gke_vpn_connection = {
+        gke_vpn_connection = {
           gke_name                = "gke-cluster"
           gke_control_plane_range = "172.16.0.0/28"
           gke_network             = "$${module.network.network.network.self_link}"

--- a/examples/tfengine/modules/team.hcl
+++ b/examples/tfengine/modules/team.hcl
@@ -192,6 +192,12 @@ template "project_apps" {
         labels = {
           type = "no-phi"
         }
+        network_peering_routes_config = {
+          network      = "network"
+          import_custom_routes = false
+          export_custom_routes = true
+          project = "{{.prefix}}-{{.env}}-networks"
+        }
       }]
       binary_authorization = {
         admission_whitelist_patterns = [{

--- a/examples/tfengine/modules/team.hcl
+++ b/examples/tfengine/modules/team.hcl
@@ -86,6 +86,7 @@ template "project_networks" {
         "iap.googleapis.com",
         "servicenetworking.googleapis.com",
         "sqladmin.googleapis.com",
+        "cloudbuild.googleapis.com",
       ]
     }
     resources = {
@@ -102,6 +103,7 @@ template "project_networks" {
             secondary_ranges = [
               {
                 name     = "pods-range"
+                // TODO double check the ip_ranges.
                 ip_range = "172.16.0.0/14"
               },
               {
@@ -150,6 +152,15 @@ EOF
 
         }]
       }]
+      private_worker_pools = [{
+        name                      = "worker-pool"
+        pool_address              = "192.168.0.0"
+        pool_prefix_length        = 16
+        create_gke_vpn_connection = {
+          gke_name                = "gke-cluster"
+          gke_control_plane_range = "172.16.0.0/28"
+        }
+      }]
     }
   }
 }
@@ -182,7 +193,12 @@ template "project_apps" {
         subnet                 = "gke-subnet"
         ip_range_pods_name     = "pods-range"
         ip_range_services_name = "services-range"
-        master_ipv4_cidr_block = "192.168.0.0/28"
+        master_ipv4_cidr_block = "172.16.0.0/28"
+
+        master_authorized_networks = [{
+          display_name: "cloudbuild"
+          cidr_block: "192.168.0.0/16"
+        }]
 
         # Set custom node pool to control machine type.
         node_pools = [{

--- a/examples/tfengine/modules/team.hcl
+++ b/examples/tfengine/modules/team.hcl
@@ -159,6 +159,7 @@ EOF
         create_gke_vpn_connection = {
           gke_name                = "gke-cluster"
           gke_control_plane_range = "172.16.0.0/28"
+          gke_network             = "$${module.network.network.network.self_link}"
         }
       }]
     }

--- a/internal/template/funcmap.go
+++ b/internal/template/funcmap.go
@@ -27,6 +27,7 @@ var funcMap = map[string]interface{}{
 	"get":               get,
 	"has":               has,
 	"hcl":               hcl,
+	"sub":               sub,
 	"hclField":          hclField,
 	"merge":             merge,
 	"replace":           replace,
@@ -81,6 +82,12 @@ func hcl(v interface{}) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(b)), nil
+}
+
+// sub computes the subtraction between two integers.
+// (e.g. sub(5, 3) returns 2.)
+func sub(a int, b int) int {
+	return a - b
 }
 
 // hclField returns a hcl marshaled field e.g. `name = "foo"`, if present.

--- a/templates/tfengine/components/resources/gke_clusters/main.tf
+++ b/templates/tfengine/components/resources/gke_clusters/main.tf
@@ -75,4 +75,14 @@ module "{{resourceName . "name"}}" {
     module.project
   ]
 }
+
+{{- if has . "network_peering_routes_config"}}
+resource "google_compute_network_peering_routes_config" "peering_{{resourceName . "name"}}" {
+  network = {{hcl .network_peering_routes_config.network}}
+  project = {{hcl .network_peering_routes_config.project}}
+  import_custom_routes = {{hcl .network_peering_routes_config.import_custom_routes}}
+  export_custom_routes = {{hcl .network_peering_routes_config.export_custom_routes}}
+  peering = module.{{resourceName . "name"}}.peering_name
+}
+{{- end}}
 {{end -}}

--- a/templates/tfengine/components/resources/private_worker_pools/main.tf
+++ b/templates/tfengine/components/resources/private_worker_pools/main.tf
@@ -1,0 +1,179 @@
+{{- /* Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */ -}}
+
+resource "google_project_service" "servicenetworking" {
+  service            = "servicenetworking.googleapis.com"
+  project            = module.project.project_id
+  disable_on_destroy = false
+}
+
+{{range $index, $worker_pool := get . "private_worker_pools" -}}
+{{$name := resourceName . "name" -}}
+module "{{$name}}_network" {
+  source  = "terraform-google-modules/network/google"
+  version = "~> 3.3.0"
+
+  network_name = "{{$worker_pool.name}}-network"
+  project_id   = module.project.project_id
+
+  subnets = []
+}
+
+resource "google_compute_global_address" "{{$name}}_address" {
+  provider      = google-beta
+  name          = "{{$worker_pool.name}}-address"
+  purpose       = "VPC_PEERING"
+  network       = module.{{$name}}_network.network_self_link
+  address_type  = "INTERNAL"
+  address       = "{{$worker_pool.pool_address}}"
+  prefix_length = {{$worker_pool.pool_prefix_length}}
+  project       = module.project.project_id
+}
+
+resource "google_service_networking_connection" "{{$name}}_connection" {
+  network                 = module.{{$name}}_network.network_self_link
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.{{$name}}_address.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network_peering_routes_config" "{{$name}}_peering" {
+  network              = module.{{$name}}_network.network_name
+  peering              = "servicenetworking-googleapis-com"
+  import_custom_routes = false
+  export_custom_routes = true
+  project              = module.project.project_id
+  depends_on = [
+    google_service_networking_connection.{{$name}}_connection,
+    module.{{$name}}_network,
+  ]
+}
+
+module "private_pool_gcloud" {
+  source                 = "terraform-google-modules/gcloud/google"
+  version                = "~> 3.0.1"
+  additional_components  = []
+  create_cmd_entrypoint  = "gcloud"
+  create_cmd_body        = "builds worker-pools create private-pool --region={{$.compute_region}} --peered-network=projects/$${module.project.project_id}/global/networks/$${module.{{$name}}_network.network_name} --project=$${module.project.project_id} --quiet"
+  destroy_cmd_entrypoint = "gcloud"
+  destroy_cmd_body       = "builds worker-pools delete private-pool --region={{$.compute_region}}  --project=$${module.project.project_id} --quiet"
+  module_depends_on = [
+    google_compute_network_peering_routes_config.{{$name}}_peering,
+  ]
+}
+
+{{- if has $worker_pool "create_gke_vpn_connection"}}
+module "{{$name}}_vpn_ha_1" {
+  source           = "terraform-google-modules/vpn/google//modules/vpn_ha"
+  version          = "~> 1.5.0"
+  project_id       = module.project.project_id
+  region           = "{{$.compute_region}}"
+  network          = module.{{$name}}_network.network_self_link
+  name             = "{{$worker_pool.name}}-net-to-{{$worker_pool.create_gke_vpn_connection.gke_name}}-net"
+  peer_gcp_gateway = module.{{$name}}_vpn_ha_2.self_link
+  router_asn       = {{sub 64514 $index}}
+  tunnels = {
+    remote-0 = {
+      bgp_peer = {
+        address = "169.254.1.1"
+        asn     = {{sub 64513 $index}}
+      }
+      bgp_peer_options = {
+        advertise_mode = "CUSTOM"
+        advertise_ip_ranges = {
+          "{{$worker_pool.pool_address}}/{{$worker_pool.pool_prefix_length}}" : ""
+        }
+        route_priority   = 1000
+        advertise_groups = null
+      }
+      bgp_session_range               = "169.254.1.2/30"
+      ike_version                     = 2
+      vpn_gateway_interface           = 0
+      peer_external_gateway_interface = null
+      shared_secret                   = ""
+    }
+    remote-1 = {
+      bgp_peer = {
+        address = "169.254.2.1"
+        asn     = {{sub 64513 $index}}
+      }
+      bgp_peer_options = {
+        advertise_mode = "CUSTOM"
+        advertise_ip_ranges = {
+          "{{$worker_pool.pool_address}}/{{$worker_pool.pool_prefix_length}}" : ""
+        }
+        route_priority   = 1000
+        advertise_groups = null
+      }
+      bgp_session_range               = "169.254.2.2/30"
+      ike_version                     = 2
+      vpn_gateway_interface           = 1
+      peer_external_gateway_interface = null
+      shared_secret                   = ""
+    }
+  }
+}
+
+module "{{$name}}_vpn_ha_2" {
+  source           = "terraform-google-modules/vpn/google//modules/vpn_ha"
+  version          = "~> 1.5.0"
+  project_id       = module.project.project_id
+  region           = "{{$.compute_region}}"
+  network          = module.123.network_self_link
+  name             = "{{$worker_pool.create_gke_vpn_connection.gke_name}}-net-to-{{$worker_pool.name}}-net"
+  router_asn       = {{sub 64513 $index}}
+  peer_gcp_gateway = module.{{$name}}_vpn_ha_1.self_link
+  tunnels = {
+    remote-0 = {
+      bgp_peer = {
+        address = "169.254.1.2"
+        asn     = {{sub 64514 $index}}
+      }
+      bgp_peer_options = {
+        advertise_mode = "CUSTOM"
+        advertise_ip_ranges = {
+          "{{$worker_pool.create_gke_vpn_connection.gke_control_plane_range}}" : ""
+        }
+        route_priority   = 1000
+        advertise_groups = null
+      }
+      bgp_session_range               = "169.254.1.1/30"
+      ike_version                     = 2
+      vpn_gateway_interface           = 0
+      peer_external_gateway_interface = null
+      shared_secret                   = module.{{$name}}_vpn_ha_1.random_secret
+    }
+    remote-1 = {
+      bgp_peer = {
+        address = "169.254.2.2"
+        asn     = {{sub 64514 $index}}
+      }
+      bgp_peer_options = {
+        advertise_mode = "CUSTOM"
+        advertise_ip_ranges = {
+          "{{$worker_pool.create_gke_vpn_connection.gke_control_plane_range}}" : ""
+        }
+        route_priority   = 1000
+        advertise_groups = null
+      }
+      bgp_session_range               = "169.254.2.1/30"
+      ike_version                     = 2
+      vpn_gateway_interface           = 1
+      peer_external_gateway_interface = null
+      shared_secret                   = module.{{$name}}_vpn_ha_1.random_secret
+    }
+  }
+}
+{{- end}}
+{{end -}}

--- a/templates/tfengine/components/resources/private_worker_pools/main.tf
+++ b/templates/tfengine/components/resources/private_worker_pools/main.tf
@@ -73,14 +73,14 @@ module "private_pool_gcloud" {
   ]
 }
 
-{{- if has $worker_pool "create_gke_vpn_connection"}}
+{{- if has $worker_pool "gke_vpn_connection"}}
 module "{{$name}}_vpn_ha_1" {
   source           = "terraform-google-modules/vpn/google//modules/vpn_ha"
   version          = "~> 1.5.0"
   project_id       = module.project.project_id
   region           = "{{$.compute_region}}"
   network          = module.{{$name}}_network.network_self_link
-  name             = "{{$worker_pool.name}}-net-to-{{$worker_pool.create_gke_vpn_connection.gke_name}}-net"
+  name             = "{{$worker_pool.name}}-net-to-{{$worker_pool.gke_vpn_connection.gke_name}}-net"
   peer_gcp_gateway = module.{{$name}}_vpn_ha_2.self_link
   router_asn       = {{sub 64514 $index}}
   tunnels = {
@@ -130,8 +130,8 @@ module "{{$name}}_vpn_ha_2" {
   version          = "~> 1.5.0"
   project_id       = module.project.project_id
   region           = "{{$.compute_region}}"
-  network          = "{{$worker_pool.create_gke_vpn_connection.gke_network}}"
-  name             = "{{$worker_pool.create_gke_vpn_connection.gke_name}}-net-to-{{$worker_pool.name}}-net"
+  network          = "{{$worker_pool.gke_vpn_connection.gke_network}}"
+  name             = "{{$worker_pool.gke_vpn_connection.gke_name}}-net-to-{{$worker_pool.name}}-net"
   router_asn       = {{sub 64513 $index}}
   peer_gcp_gateway = module.{{$name}}_vpn_ha_1.self_link
   tunnels = {
@@ -143,7 +143,7 @@ module "{{$name}}_vpn_ha_2" {
       bgp_peer_options = {
         advertise_mode = "CUSTOM"
         advertise_ip_ranges = {
-          "{{$worker_pool.create_gke_vpn_connection.gke_control_plane_range}}" : ""
+          "{{$worker_pool.gke_vpn_connection.gke_control_plane_range}}" : ""
         }
         route_priority   = 1000
         advertise_groups = null
@@ -162,7 +162,7 @@ module "{{$name}}_vpn_ha_2" {
       bgp_peer_options = {
         advertise_mode = "CUSTOM"
         advertise_ip_ranges = {
-          "{{$worker_pool.create_gke_vpn_connection.gke_control_plane_range}}" : ""
+          "{{$worker_pool.gke_vpn_connection.gke_control_plane_range}}" : ""
         }
         route_priority   = 1000
         advertise_groups = null

--- a/templates/tfengine/components/resources/private_worker_pools/main.tf
+++ b/templates/tfengine/components/resources/private_worker_pools/main.tf
@@ -130,7 +130,7 @@ module "{{$name}}_vpn_ha_2" {
   version          = "~> 1.5.0"
   project_id       = module.project.project_id
   region           = "{{$.compute_region}}"
-  network          = module.123.network_self_link
+  network          = "{{$worker_pool.create_gke_vpn_connection.gke_network}}"
   name             = "{{$worker_pool.create_gke_vpn_connection.gke_name}}-net-to-{{$worker_pool.name}}-net"
   router_asn       = {{sub 64513 $index}}
   peer_gcp_gateway = module.{{$name}}_vpn_ha_1.self_link

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -695,7 +695,7 @@ schema = {
             description = "The prefix length of the worker pool IP range."
             type        = "integer"
           }
-          create_gke_vpn_connection = {
+          gke_vpn_connection = {
             description = <<EOF
               HA VPN connection between the private worker pool vpc and the gke network vpc.
               See <https://registry.terraform.io/modules/terraform-google-modules/vpn/google/latest/submodules/vpn_ha>.

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -660,6 +660,66 @@ schema = {
         }
       }
     }
+    private_worker_pools = {
+      description = <<EOF
+        Cloudbuild private worker pool config.
+
+        This creates a worker pool with a dedicated computer network subnet
+        and creates a peering connection with the subnet.
+        
+        Must be created in the networks project used in the GKE cluster.
+      EOF
+      type        = "array"
+      items = {
+        type                 = "object"
+        additionalProperties = false
+        required = [
+          "name",
+          "pool_address",
+          "pool_prefix_length"
+        ]
+        properties = {
+          name = {
+            description = "Name of private worker pool."
+            type        = "string"
+          }
+          compute_region = {
+            description = "Region to create worker pool in. Can be defined in global data block."
+            type        = "string"
+          }
+          pool_address = {
+            description = "IP address of the worker pool IP range."
+            type        = "string"
+          }
+          pool_prefix_length = {
+            description = "The prefix length of the worker pool IP range."
+            type        = "integer"
+          }
+          create_gke_vpn_connection = {
+            description = <<EOF
+              HA VPN connection between the private worker pool vpc and the gke network vpc.
+              See <https://registry.terraform.io/modules/terraform-google-modules/vpn/google/latest/submodules/vpn_ha>.
+            EOF
+            type                 = "object"
+            additionalProperties = false
+            required = [
+              "gke_name",
+              "gke_control_plane_range"
+            ]
+            properties = {
+              gke_name = {
+                description = "Name of the GKE cluster the worker pool can access."
+                type        = "string"
+              }
+              gke_control_plane_range = {
+                description = "The CIDR of the gke cluster control plane range. E.g. 192.168.0.0/28."
+                type        = "string"
+              }
+            }
+          }
+        }
+      }
+    }
     gke_clusters = {
       description = "[Module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/modules/safer-cluster-update-variant)"
       type        = "array"
@@ -1703,6 +1763,12 @@ template "storage_buckets" {
 {{if has . "groups"}}
 template "groups" {
   component_path = "../components/resources/groups"
+}
+{{end}}
+
+{{if has . "private_worker_pools"}}
+template "private_worker_pools" {
+  component_path = "../components/resources/private_worker_pools"
 }
 {{end}}
 

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -704,7 +704,8 @@ schema = {
             additionalProperties = false
             required = [
               "gke_name",
-              "gke_control_plane_range"
+              "gke_control_plane_range",
+              "gke_network"
             ]
             properties = {
               gke_name = {
@@ -714,6 +715,10 @@ schema = {
               gke_control_plane_range = {
                 description = "The CIDR of the gke cluster control plane range. E.g. 192.168.0.0/28."
                 type        = "string"
+              }
+              gke_network = {
+                description = "Name of the bastion host's subnet."
+                type = "string"
               }
             }
           }

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -770,6 +770,31 @@ schema = {
             EOF
             type        = "boolean"
           }
+          network_peering_routes_config = {
+            description = <<EOF
+              GKE clustes network peering's route settings.
+              See <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering_routes_config>.
+            EOF
+            type        = "object"
+            properties = {
+              "network" = {
+                description = "The name of the primary network for the peering."
+                type        = "string"
+              }
+              "export_custom_routes" = {
+                description = "Whether to export the custom routes to the peer network."
+                type        = "boolean"
+              }
+              "import_custom_routes" = {
+                description = "Whether to import the custom routes to the peer network."
+                type        = "boolean"
+              }
+              "project" = {
+                description = "The ID of the project in which the resource belongs."
+                type        = "string"
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
* Add the option to peer a GKE cluster network with another VPC.
* Add private worker pools to resources and surface minimal configs for easy implementation.
* Add the option to connect the worker pool with the GKE network VPC using HA VPN connections.

Fix #996 