### PR TITLE
Support reading hl7v2 parser config from file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 # Terraform state
 *.tfstate
 *.tfstate.*
+
+# Intellij IDE configuration dir.
+.idea/

--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -180,7 +180,7 @@
 | healthcare_datasets.hl7_v2_stores.parser_config | See <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/healthcare_hl7_v2_store#parser_config>. | object | false | - | - |
 | healthcare_datasets.hl7_v2_stores.parser_config.allow_null_header | - | boolean | false | - | - |
 | healthcare_datasets.hl7_v2_stores.parser_config.schema | - | string | false | - | - |
-| healthcare_datasets.hl7_v2_stores.parser_config.schema_file | Path to the JSON encoded schema file. | string | false | - | - |
+| healthcare_datasets.hl7_v2_stores.parser_config.schema_file | Path to the JSON encoded schema file. Only one of the schema_file or schema field should be provided, not both. | string | false | - | - |
 | healthcare_datasets.hl7_v2_stores.parser_config.segment_terminator | - | string | false | - | - |
 | healthcare_datasets.hl7_v2_stores.parser_config.version | - | string | false | - | - |
 | healthcare_datasets.iam_members | IAM member to grant access for. | array(object) | false | - | - |

--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -180,6 +180,7 @@
 | healthcare_datasets.hl7_v2_stores.parser_config | See <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/healthcare_hl7_v2_store#parser_config>. | object | false | - | - |
 | healthcare_datasets.hl7_v2_stores.parser_config.allow_null_header | - | boolean | false | - | - |
 | healthcare_datasets.hl7_v2_stores.parser_config.schema | - | string | false | - | - |
+| healthcare_datasets.hl7_v2_stores.parser_config.schema_file | Path to the JSON encoded schema file. | string | false | - | - |
 | healthcare_datasets.hl7_v2_stores.parser_config.segment_terminator | - | string | false | - | - |
 | healthcare_datasets.hl7_v2_stores.parser_config.version | - | string | false | - | - |
 | healthcare_datasets.iam_members | IAM member to grant access for. | array(object) | false | - | - |

--- a/examples/tfengine/generated/team/project_data/hl7_config_schema.json
+++ b/examples/tfengine/generated/team/project_data/hl7_config_schema.json
@@ -2,3 +2,4 @@
   "schematizedParsingType": "SOFT_FAIL",
   "ignoreMinOccurs": true
 }
+

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -196,12 +196,7 @@ module "healthcare_dataset" {
       ]
       parser_config = {
         version = "V2"
-        schema  = <<EOF
-{
-  "schematizedParsingType": "SOFT_FAIL",
-  "ignoreMinOccurs": true
-}
-EOF
+        schema  = templatefile("./schema.json", {})
       }
       labels = {
         env  = "prod"

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -196,7 +196,7 @@ module "healthcare_dataset" {
       ]
       parser_config = {
         version = "V2"
-        schema  = templatefile("./schema.json", {})
+        schema  = templatefile("./hl7_config_schema.json", {})
       }
       labels = {
         env  = "prod"

--- a/examples/tfengine/generated/team/project_data/schema.json
+++ b/examples/tfengine/generated/team/project_data/schema.json
@@ -1,0 +1,4 @@
+{
+  "schematizedParsingType": "SOFT_FAIL",
+  "ignoreMinOccurs": true
+}

--- a/examples/tfengine/modules/schema/hl7_config_schema.json
+++ b/examples/tfengine/modules/schema/hl7_config_schema.json
@@ -2,3 +2,4 @@
   "schematizedParsingType": "SOFT_FAIL",
   "ignoreMinOccurs": true
 }
+

--- a/examples/tfengine/modules/schema/hl7_config_schema.json
+++ b/examples/tfengine/modules/schema/hl7_config_schema.json
@@ -1,0 +1,4 @@
+{
+  "schematizedParsingType": "SOFT_FAIL",
+  "ignoreMinOccurs": true
+}

--- a/examples/tfengine/modules/team.hcl
+++ b/examples/tfengine/modules/team.hcl
@@ -330,7 +330,10 @@ EOF
     }
   }
 }
-
+template "schema" {
+  component_path = "./schema/hl7_config_schema.json"
+  output_path = "./project_data/schema.json"
+}
 # Prod central data project for team 1.
 template "project_data" {
   recipe_path = "{{.recipes}}/project.hcl"
@@ -445,12 +448,7 @@ template "project_data" {
             pubsub_topic = "projects/{{.prefix}}-{{.env}}-data/topics/$${module.topic.topic}"
           }]
           parser_config = {
-            schema  = <<EOF
-{
-  "schematizedParsingType": "SOFT_FAIL",
-  "ignoreMinOccurs": true
-}
-EOF
+            schema_file  = "./schema.json"
             version = "V2"
           }
           labels = {

--- a/examples/tfengine/modules/team.hcl
+++ b/examples/tfengine/modules/team.hcl
@@ -332,7 +332,7 @@ EOF
 }
 template "schema" {
   component_path = "./schema/hl7_config_schema.json"
-  output_path = "./project_data/schema.json"
+  output_path = "./project_data/hl7_config_schema.json"
 }
 # Prod central data project for team 1.
 template "project_data" {
@@ -448,7 +448,7 @@ template "project_data" {
             pubsub_topic = "projects/{{.prefix}}-{{.env}}-data/topics/$${module.topic.topic}"
           }]
           parser_config = {
-            schema_file  = "./schema.json"
+            schema_file  = "./hl7_config_schema.json"
             version = "V2"
           }
           labels = {

--- a/templates/tfengine/components/resources/healthcare_datasets/main.tf
+++ b/templates/tfengine/components/resources/healthcare_datasets/main.tf
@@ -133,6 +133,8 @@ module "{{resourceName . "name"}}" {
         schema = <<EOF
 {{.parser_config.schema -}}
         EOF
+        {{- else if has .parser_config "schema_file" -}}
+        schema = templatefile("{{.parser_config.schema_file -}}", {})
         {{- end}}
       }
       {{end -}}

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -1109,7 +1109,7 @@ schema = {
                       type = "string"
                     }
                     schema_file = {
-                      description = "Path to the JSON encoded schema file."
+                      description = "Path to the JSON encoded schema file. Only one of the schema_file or schema field should be provided, not both."
                       type = "string"
                     }
                     version = {

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -1108,6 +1108,10 @@ schema = {
                     schema = {
                       type = "string"
                     }
+                    schema_file = {
+                      description = "Path to the JSON encoded schema file."
+                      type = "string"
+                    }
                     version = {
                       type = "string"
                     }


### PR DESCRIPTION
Deployed the change in HDE instance for testing.
instance prefix : test-dpt1
Verified that the parser config through schema_file has been applied to hl7 store successfully.
https://screenshot.googleplex.com/8NJfhrimp44YaKB.png