### PR TITLE
Delete Solution Guide section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ Note that YAML-formatted configs were used at the time when the Tutorial video
 was made. The config format has been changed to
 [HCL](https://github.com/hashicorp/hcl).
 
-## Solution Guide
-
-[Google Cloud Data Protection Toolkit guide](https://cloud.google.com/solutions/data-protection-toolkit-guide)
-
 ## Releases
 
 Please see [RELEASING.md](./RELEASING.md) for our release strategy.


### PR DESCRIPTION
Removed because https://cloud.google.com/solutions/data-protection-toolkit-guide has been removed and redirected to https://cloud.google.com/security/transparency.