### PR TITLE
Use google-beta for healthcare stores to use V3 HL7 parser

### DIFF
--- a/examples/tfengine/generated/resources_only/resources/main.tf
+++ b/examples/tfengine/generated/resources_only/resources/main.tf
@@ -59,8 +59,9 @@ module "one_billion_ms_example_dataset" {
 }
 
 module "example_healthcare_dataset" {
-  source  = "terraform-google-modules/healthcare/google"
-  version = "~> 2.1.0"
+  source   = "terraform-google-modules/healthcare/google"
+  version  = "~> 2.1.0"
+  provider = google-beta
 
   name     = "example-healthcare-dataset"
   project  = module.project.project_id

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -115,8 +115,9 @@ module "sql_instance" {
 }
 
 module "healthcare_dataset" {
-  source  = "terraform-google-modules/healthcare/google"
-  version = "~> 2.1.0"
+  source   = "terraform-google-modules/healthcare/google"
+  version  = "~> 2.1.0"
+  provider = google-beta
 
   name     = "healthcare-dataset"
   project  = module.project.project_id

--- a/templates/tfengine/components/resources/healthcare_datasets/main.tf
+++ b/templates/tfengine/components/resources/healthcare_datasets/main.tf
@@ -16,6 +16,7 @@ limitations under the License. */ -}}
 module "{{resourceName . "name"}}" {
   source  = "terraform-google-modules/healthcare/google"
   version = "~> 2.1.0"
+  provider = google-beta
 
   name     = "{{.name}}"
   project  = module.project.project_id


### PR DESCRIPTION
V3 HL7 and V2 BQ export schema are beta only features, released in https://github.com/hashicorp/terraform-provider-google-beta/releases/tag/v4.17.0