### PR TITLE
Upgrade project-factory version so we can use 4.x provider versions.

### DIFF
--- a/examples/tfengine/generated/devops/devops/main.tf
+++ b/examples/tfengine/generated/devops/devops/main.tf
@@ -33,7 +33,7 @@ terraform {
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-devops"
   org_id          = "12345678"

--- a/examples/tfengine/generated/devops/groups/main.tf
+++ b/examples/tfengine/generated/devops/groups/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id    = "example-devops"
   activate_apis = []

--- a/examples/tfengine/generated/folder_foundation/audit/main.tf
+++ b/examples/tfengine/generated/folder_foundation/audit/main.tf
@@ -30,7 +30,7 @@ terraform {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-audit"
   org_id          = ""

--- a/examples/tfengine/generated/folder_foundation/devops/main.tf
+++ b/examples/tfengine/generated/folder_foundation/devops/main.tf
@@ -33,7 +33,7 @@ terraform {
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-devops"
   org_id          = ""

--- a/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
@@ -30,7 +30,7 @@ terraform {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-prod-networks"
   org_id          = ""

--- a/examples/tfengine/generated/folder_foundation/groups/main.tf
+++ b/examples/tfengine/generated/folder_foundation/groups/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id    = "example-devops"
   activate_apis = []

--- a/examples/tfengine/generated/gke_cluster/gke_cluster/cluster/main.tf
+++ b/examples/tfengine/generated/gke_cluster/gke_cluster/cluster/main.tf
@@ -30,7 +30,7 @@ terraform {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-apps"
   org_id          = "12345678"

--- a/examples/tfengine/generated/gke_cluster/gke_cluster/kubernetes/main.tf
+++ b/examples/tfengine/generated/gke_cluster/gke_cluster/kubernetes/main.tf
@@ -45,7 +45,7 @@ provider "kubernetes" {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id    = "example-apps"
   activate_apis = []

--- a/examples/tfengine/generated/gke_cluster/gke_cluster/networks/main.tf
+++ b/examples/tfengine/generated/gke_cluster/gke_cluster/networks/main.tf
@@ -30,7 +30,7 @@ terraform {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-networks"
   org_id          = "12345678"

--- a/examples/tfengine/generated/multi_envs/audit/main.tf
+++ b/examples/tfengine/generated/multi_envs/audit/main.tf
@@ -30,7 +30,7 @@ terraform {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-audit"
   org_id          = ""

--- a/examples/tfengine/generated/multi_envs/dev/data/main.tf
+++ b/examples/tfengine/generated/multi_envs/dev/data/main.tf
@@ -37,7 +37,7 @@ data "terraform_remote_state" "folders" {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-data-dev"
   org_id          = ""

--- a/examples/tfengine/generated/multi_envs/devops/main.tf
+++ b/examples/tfengine/generated/multi_envs/devops/main.tf
@@ -39,7 +39,7 @@ provider "google-beta" {
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-devops"
   org_id          = ""

--- a/examples/tfengine/generated/multi_envs/groups/main.tf
+++ b/examples/tfengine/generated/multi_envs/groups/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id    = "example-devops"
   activate_apis = []

--- a/examples/tfengine/generated/multi_envs/prod/data/main.tf
+++ b/examples/tfengine/generated/multi_envs/prod/data/main.tf
@@ -37,7 +37,7 @@ data "terraform_remote_state" "folders" {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-data-prod"
   org_id          = ""

--- a/examples/tfengine/generated/org_foundation/audit/main.tf
+++ b/examples/tfengine/generated/org_foundation/audit/main.tf
@@ -30,7 +30,7 @@ terraform {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-audit"
   org_id          = "12345678"

--- a/examples/tfengine/generated/org_foundation/devops/main.tf
+++ b/examples/tfengine/generated/org_foundation/devops/main.tf
@@ -33,7 +33,7 @@ terraform {
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-devops"
   org_id          = "12345678"

--- a/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
@@ -30,7 +30,7 @@ terraform {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-prod-networks"
   org_id          = "12345678"

--- a/examples/tfengine/generated/org_foundation/groups/main.tf
+++ b/examples/tfengine/generated/org_foundation/groups/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id    = "example-devops"
   activate_apis = []

--- a/examples/tfengine/generated/resources_only/resources/main.tf
+++ b/examples/tfengine/generated/resources_only/resources/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id    = "example-prod-project"
   activate_apis = []

--- a/examples/tfengine/generated/team/devops/main.tf
+++ b/examples/tfengine/generated/team/devops/main.tf
@@ -39,7 +39,7 @@ provider "google-beta" {
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-prod-devops"
   org_id          = ""

--- a/examples/tfengine/generated/team/groups/main.tf
+++ b/examples/tfengine/generated/team/groups/main.tf
@@ -28,7 +28,7 @@ terraform {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id    = "example-prod-devops"
   activate_apis = []

--- a/examples/tfengine/generated/team/kubernetes/main.tf
+++ b/examples/tfengine/generated/team/kubernetes/main.tf
@@ -45,7 +45,7 @@ provider "kubernetes" {
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id    = "example-prod-apps"
   activate_apis = []

--- a/examples/tfengine/generated/team/project_apps/main.tf
+++ b/examples/tfengine/generated/team/project_apps/main.tf
@@ -36,7 +36,7 @@ resource "google_compute_address" "static" {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-prod-apps"
   org_id          = ""

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -38,7 +38,7 @@ data "google_secret_manager_secret_version" "db_password" {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-prod-data"
   org_id          = ""

--- a/examples/tfengine/generated/team/project_networks/main.tf
+++ b/examples/tfengine/generated/team/project_networks/main.tf
@@ -30,7 +30,7 @@ terraform {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-prod-networks"
   org_id          = ""

--- a/examples/tfengine/generated/team/project_secrets/main.tf
+++ b/examples/tfengine/generated/team/project_secrets/main.tf
@@ -36,7 +36,7 @@ resource "random_password" "db" {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "example-prod-secrets"
   org_id          = ""

--- a/templates/tfengine/components/devops/main.tf
+++ b/templates/tfengine/components/devops/main.tf
@@ -33,7 +33,7 @@ provider "google-beta" {
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "{{.project.project_id}}"
   {{- if eq .parent_type "organization"}}

--- a/templates/tfengine/components/project/main.tf
+++ b/templates/tfengine/components/project/main.tf
@@ -12,7 +12,7 @@ limitations under the License. */ -}}
 {{- if get . "exists"}}
 module "project" {
   source = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   project_id =  "{{.project_id}}"
   activate_apis = {{- if has . "apis"}} {{hcl .apis}} {{- else}} [] {{end}}
@@ -23,7 +23,7 @@ module "project" {
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 11.2.0"
+  version = "~> 11.3.0"
 
   name            = "{{.project_id}}"
   {{- if eq .parent_type "organization"}}


### PR DESCRIPTION
The old version (11.1.1) [did not allow](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/v11.1.1/modules/project_services/versions.tf#L22) provider versions 4.0 or higher.