### PR TITLE
Remove Cloud Scheduler AppEngine Dependency app

### DIFF
--- a/build/md_check.sh
+++ b/build/md_check.sh
@@ -20,5 +20,5 @@ npm version
 
 # Check format
 # Note: Requires Node 10+ (see https://github.com/igorshubovych/markdownlint-cli/issues/90)
-npm install -g markdownlint-cli
+npm install -g markdownlint-cli@0.31.1
 markdownlint **/*.md --ignore examples/policygen/generated

--- a/docs/tfengine/schemas/cicd.md
+++ b/docs/tfengine/schemas/cicd.md
@@ -36,7 +36,7 @@
 | grant_automation_billing_user_role | Whether or not to grant automation service account the billing.user role. Default to true. | boolean | false | - | - |
 | logs_bucket | Name of the Google Cloud Storage bucket where Cloud Build logs should be written. The bucket will be created as part of CICD. | string | true | - | - |
 | project_id | ID of project to deploy CICD in. | string | false | - | ^[a-z][a-z0-9\-]{4,28}[a-z0-9]$ |
-| scheduler_region | [Region](https://cloud.google.com/appengine/docs/locations) where the scheduler job (or the App Engine App behind the sceneces) resides. Must be specified if any triggers are configured to be run on schedule. | string | true | - | - |
+| scheduler_region | [Region](https://cloud.google.com/sdk/gcloud/reference/scheduler/locations/list) where the scheduler job resides. Must be specified if any triggers are configured to be run on schedule. | string | true | - | - |
 | service_account | The custom service account to run Cloud Build triggers. During the CICD deployment, this service account will be granted all necessary permissions to provision and manage your infrastructure. See <https://cloud.google.com/build/docs/securing-builds/configure-user-specified-service-accounts#permissions> for more details. | object | true | - | - |
 | service_account.exists | Whether the service account exists. Defaults to 'false'. | boolean | false | - | - |
 | service_account.id | ID of the service account. | string | true | - | - |

--- a/examples/tfengine/generated/devops/cicd/main.tf
+++ b/examples/tfengine/generated/devops/cicd/main.tf
@@ -157,17 +157,6 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   ]
 }
 
-# Cloud Scheduler resources.
-# Cloud Scheduler requires an App Engine app created in the project.
-# App Engine app cannot be destroyed once created, therefore always create it.
-resource "google_app_engine_application" "cloudbuild_scheduler_app" {
-  project     = var.project_id
-  location_id = "us-east1"
-  depends_on = [
-    google_project_service.services,
-  ]
-}
-
 # Service Account and its IAM permissions used for Cloud Scheduler to schedule Cloud Build triggers.
 resource "google_service_account" "cloudbuild_scheduler_sa" {
   project      = var.project_id

--- a/examples/tfengine/generated/devops/cicd/triggers.tf
+++ b/examples/tfengine/generated/devops/cicd/triggers.tf
@@ -134,7 +134,6 @@ resource "google_cloud_scheduler_job" "plan_scheduler_prod" {
   }
   depends_on = [
     google_project_service.services,
-    google_app_engine_application.cloudbuild_scheduler_app,
   ]
 }
 

--- a/examples/tfengine/generated/folder_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/main.tf
@@ -155,17 +155,6 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   ]
 }
 
-# Cloud Scheduler resources.
-# Cloud Scheduler requires an App Engine app created in the project.
-# App Engine app cannot be destroyed once created, therefore always create it.
-resource "google_app_engine_application" "cloudbuild_scheduler_app" {
-  project     = var.project_id
-  location_id = "us-east1"
-  depends_on = [
-    google_project_service.services,
-  ]
-}
-
 # Service Account and its IAM permissions used for Cloud Scheduler to schedule Cloud Build triggers.
 resource "google_service_account" "cloudbuild_scheduler_sa" {
   project      = var.project_id

--- a/examples/tfengine/generated/folder_foundation/cicd/triggers.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/triggers.tf
@@ -134,7 +134,6 @@ resource "google_cloud_scheduler_job" "plan_scheduler_prod" {
   }
   depends_on = [
     google_project_service.services,
-    google_app_engine_application.cloudbuild_scheduler_app,
   ]
 }
 

--- a/examples/tfengine/generated/multi_envs/cicd/main.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/main.tf
@@ -182,17 +182,6 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
     google_project_service.services,
   ]
 }
-
-# Cloud Scheduler resources.
-# Cloud Scheduler requires an App Engine app created in the project.
-# App Engine app cannot be destroyed once created, therefore always create it.
-resource "google_app_engine_application" "cloudbuild_scheduler_app" {
-  project     = var.project_id
-  location_id = "us-east1"
-  depends_on = [
-    google_project_service.services,
-  ]
-}
 # Cloud Build - Service Account replacing the default Cloud Build Service Account.
 resource "google_service_account" "cloudbuild_sa" {
   project      = var.project_id

--- a/examples/tfengine/generated/org_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/org_foundation/cicd/main.tf
@@ -154,17 +154,6 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
     google_project_service.services,
   ]
 }
-
-# Cloud Scheduler resources.
-# Cloud Scheduler requires an App Engine app created in the project.
-# App Engine app cannot be destroyed once created, therefore always create it.
-resource "google_app_engine_application" "cloudbuild_scheduler_app" {
-  project     = var.project_id
-  location_id = "us-east1"
-  depends_on = [
-    google_project_service.services,
-  ]
-}
 # Cloud Build - Service Account replacing the default Cloud Build Service Account.
 resource "google_service_account" "cloudbuild_sa" {
   project      = var.project_id

--- a/examples/tfengine/generated/team/cicd/main.tf
+++ b/examples/tfengine/generated/team/cicd/main.tf
@@ -162,17 +162,6 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
     google_project_service.services,
   ]
 }
-
-# Cloud Scheduler resources.
-# Cloud Scheduler requires an App Engine app created in the project.
-# App Engine app cannot be destroyed once created, therefore always create it.
-resource "google_app_engine_application" "cloudbuild_scheduler_app" {
-  project     = var.project_id
-  location_id = "us-east1"
-  depends_on = [
-    google_project_service.services,
-  ]
-}
 # Cloud Build - Service Account replacing the default Cloud Build Service Account.
 resource "google_service_account" "cloudbuild_sa" {
   project      = var.project_id

--- a/templates/tfengine/components/cicd/main.tf
+++ b/templates/tfengine/components/cicd/main.tf
@@ -229,17 +229,6 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   ]
 }
 
-# Cloud Scheduler resources.
-# Cloud Scheduler requires an App Engine app created in the project.
-# App Engine app cannot be destroyed once created, therefore always create it.
-resource "google_app_engine_application" "cloudbuild_scheduler_app" {
-  project     = var.project_id
-  location_id = "{{.scheduler_region}}"
-  depends_on = [
-    google_project_service.services,
-  ]
-}
-
 {{- if $hasScheduledJobs}}
 
 # Service Account and its IAM permissions used for Cloud Scheduler to schedule Cloud Build triggers.

--- a/templates/tfengine/components/cicd/triggers.tf
+++ b/templates/tfengine/components/cicd/triggers.tf
@@ -149,7 +149,6 @@ resource "google_cloud_scheduler_job" "validate_scheduler_{{.name}}" {
   }
   depends_on = [
     google_project_service.services,
-    google_app_engine_application.cloudbuild_scheduler_app,
   ]
 }
 {{- end}}
@@ -269,7 +268,6 @@ resource "google_cloud_scheduler_job" "plan_scheduler_{{.name}}" {
   }
   depends_on = [
     google_project_service.services,
-    google_app_engine_application.cloudbuild_scheduler_app,
   ]
 }
 {{- end}}
@@ -343,7 +341,6 @@ resource "google_cloud_scheduler_job" "apply_scheduler_{{.name}}" {
   }
   depends_on = [
     google_project_service.services,
-    google_app_engine_application.cloudbuild_scheduler_app,
   ]
 }
 {{- end}}

--- a/templates/tfengine/recipes/cicd.hcl
+++ b/templates/tfengine/recipes/cicd.hcl
@@ -109,8 +109,8 @@ schema = {
     }
     scheduler_region = {
       description = <<EOF
-        [Region](https://cloud.google.com/appengine/docs/locations) where the scheduler
-        job (or the App Engine App behind the sceneces) resides. Must be specified if
+        [Region](https://cloud.google.com/sdk/gcloud/reference/scheduler/locations/list) where the scheduler
+        job resides. Must be specified if
         any triggers are configured to be run on schedule.
       EOF
       type        = "string"


### PR DESCRIPTION
Cloud Scheduler jobs for HTTP or Pub/Sub Targets can be deployed in multiple GCP Regions around the world and no longer require that an App Engine application be deployed.

Pin markdownlint-cli to version 0.31.1 to disable rule MD052, which is breaking presubmit_unit tests.

Release note: https://cloud.google.com/scheduler/docs/release-notes#February_11_2022