### PR TITLE
Upgrading the terraform-google-pubsub module to release 4.0.0

### DIFF
--- a/examples/tfengine/generated/devops/cicd/main.tf
+++ b/examples/tfengine/generated/devops/cicd/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/devops/devops/main.tf
+++ b/examples/tfengine/generated/devops/devops/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
 }

--- a/examples/tfengine/generated/devops/groups/main.tf
+++ b/examples/tfengine/generated/devops/groups/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/folder_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/folder_foundation/devops/main.tf
+++ b/examples/tfengine/generated/folder_foundation/devops/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
 }

--- a/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/folder_foundation/folders/main.tf
+++ b/examples/tfengine/generated/folder_foundation/folders/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/folder_foundation/groups/main.tf
+++ b/examples/tfengine/generated/folder_foundation/groups/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/gke_cluster/gke_cluster/cluster/main.tf
+++ b/examples/tfengine/generated/gke_cluster/gke_cluster/cluster/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/gke_cluster/gke_cluster/kubernetes/main.tf
+++ b/examples/tfengine/generated/gke_cluster/gke_cluster/kubernetes/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/gke_cluster/gke_cluster/networks/main.tf
+++ b/examples/tfengine/generated/gke_cluster/gke_cluster/networks/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/iam_members/iam_members/main.tf
+++ b/examples/tfengine/generated/iam_members/iam_members/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/multi_envs/audit/main.tf
+++ b/examples/tfengine/generated/multi_envs/audit/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/multi_envs/cicd/main.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/multi_envs/dev/data/main.tf
+++ b/examples/tfengine/generated/multi_envs/dev/data/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/multi_envs/devops/main.tf
+++ b/examples/tfengine/generated/multi_envs/devops/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
 }

--- a/examples/tfengine/generated/multi_envs/folders/main.tf
+++ b/examples/tfengine/generated/multi_envs/folders/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/multi_envs/groups/main.tf
+++ b/examples/tfengine/generated/multi_envs/groups/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/multi_envs/prod/data/main.tf
+++ b/examples/tfengine/generated/multi_envs/prod/data/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/org_foundation/audit/main.tf
+++ b/examples/tfengine/generated/org_foundation/audit/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/org_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/org_foundation/cicd/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/org_foundation/devops/main.tf
+++ b/examples/tfengine/generated/org_foundation/devops/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
 }

--- a/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/org_foundation/folders/main.tf
+++ b/examples/tfengine/generated/org_foundation/folders/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/org_foundation/groups/main.tf
+++ b/examples/tfengine/generated/org_foundation/groups/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/org_foundation/org_policies/main.tf
+++ b/examples/tfengine/generated/org_foundation/org_policies/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/org_policies/org_policies/main.tf
+++ b/examples/tfengine/generated/org_policies/org_policies/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/resources_only/resources/main.tf
+++ b/examples/tfengine/generated/resources_only/resources/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/team/additional_iam_members/main.tf
+++ b/examples/tfengine/generated/team/additional_iam_members/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/team/groups/main.tf
+++ b/examples/tfengine/generated/team/groups/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/team/kubernetes/main.tf
+++ b/examples/tfengine/generated/team/kubernetes/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/team/project_apps/main.tf
+++ b/examples/tfengine/generated/team/project_apps/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -225,7 +225,7 @@ module "project_iam_members" {
 
 module "topic" {
   source  = "terraform-google-modules/pubsub/google"
-  version = "~> 3.1.0"
+  version = "~> 4.0.0"
 
   topic      = "topic"
   project_id = module.project.project_id

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {
@@ -95,7 +95,7 @@ module "one_billion_ms_dataset" {
 
 module "sql_instance" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/safer_mysql"
-  version = "~> 4.5.0"
+  version = "~> 9.0.0"
 
   name                = "sql-instance"
   project_id          = module.project.project_id

--- a/examples/tfengine/generated/team/project_networks/main.tf
+++ b/examples/tfengine/generated/team/project_networks/main.tf
@@ -15,8 +15,8 @@
 terraform {
   required_version = ">=0.14"
   required_providers {
-    google      = "~> 3.0"
-    google-beta = "~> 3.0"
+    google      = ">= 3.0"
+    google-beta = ">= 3.0"
     kubernetes  = "~> 1.0"
   }
   backend "gcs" {
@@ -134,7 +134,7 @@ module "network" {
 }
 module "cloud_sql_private_service_access_network" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/private_service_access"
-  version = "~> 4.5.0"
+  version = "~> 9.0.0"
 
   project_id  = module.project.project_id
   vpc_network = module.network.network_name

--- a/templates/tfengine/components/resources/cloud_sql_instances/main.tf
+++ b/templates/tfengine/components/resources/cloud_sql_instances/main.tf
@@ -21,7 +21,7 @@ limitations under the License. */ -}}
 {{if eq .type "mysql" -}}
 module "{{resourceName . "name"}}" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/safer_mysql"
-  version = "~> 4.5.0"
+  version = "~> 9.0.0"
 
   name              = "{{.name}}"
   project_id        = module.project.project_id

--- a/templates/tfengine/components/resources/compute_networks/main.tf
+++ b/templates/tfengine/components/resources/compute_networks/main.tf
@@ -60,7 +60,7 @@ module "{{$resource_name}}" {
 {{- if has . "cloud_sql_private_service_access"}}
 module "cloud_sql_private_service_access_{{$resource_name}}" {
   source  = "GoogleCloudPlatform/sql-db/google//modules/private_service_access"
-  version = "~> 4.5.0"
+  version = "~> 9.0.0"
 
   project_id  = module.project.project_id
   vpc_network = module.{{$resource_name}}.network_name

--- a/templates/tfengine/components/resources/pubsub_topics/main.tf
+++ b/templates/tfengine/components/resources/pubsub_topics/main.tf
@@ -15,7 +15,7 @@ limitations under the License. */ -}}
 {{range .pubsub_topics}}
 module "{{resourceName . "name"}}" {
   source  = "terraform-google-modules/pubsub/google"
-  version = "~> 3.1.0"
+  version = "~> 4.0.0"
 
   topic        = "{{.name}}"
   project_id   = module.project.project_id

--- a/templates/tfengine/components/terraform/main/main.tf
+++ b/templates/tfengine/components/terraform/main/main.tf
@@ -34,10 +34,10 @@ terraform {
   {{end -}}
 {{end -}}
     {{if not $hasGoogle -}}
-    google      = "~> 3.0"
+    google      = ">= 3.0"
     {{end -}}
     {{if not $hasGoogleBeta -}}
-    google-beta = "~> 3.0"
+    google-beta = ">= 3.0"
     {{end -}}
     {{if not $hasKubernetes -}}
     kubernetes  = "~> 1.0"


### PR DESCRIPTION
Provides access to message_retention_duration on topics and exactly once delivery on
subscriptions.

The release for terraform-google-pubsub is published here: https://github.com/terraform-google-modules/terraform-google-pubsub/releases/tag/v4.0.0