### PR TITLE
Update docker image for cloud build triggers

### DIFF
--- a/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/devops/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/devops/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/templates/tfengine/components/cicd/configs/tf-apply.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-apply.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"}}
 
 timeout: 21600s
 

--- a/templates/tfengine/components/cicd/configs/tf-plan.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-plan.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"}}
 
 timeout: 1200s
 

--- a/templates/tfengine/components/cicd/configs/tf-validate.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-validate.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:42d746379f734577e1f69c6f1c848928da65aa1ab37d56a3430abc23d6cd1954"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:1d190af9b42a6ad36ad98690ea2b7a668f2870422e009f825c7ffc357a37ab94"}}
 
 timeout: 600s
 


### PR DESCRIPTION
Updated developer-tools-light to 1.7.1 which has updated the base image to 3.16.2
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/1259