### PR TITLE
Update cloud build container image, pubsub module, and bigquery module

### DIFF
--- a/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/devops/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/devops/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/resources_only/resources/main.tf
+++ b/examples/tfengine/generated/resources_only/resources/main.tf
@@ -36,7 +36,7 @@ module "project" {
 
 module "one_billion_ms_example_dataset" {
   source  = "terraform-google-modules/bigquery/google"
-  version = "~> 5.3.0"
+  version = "~> 7.0.0"
 
   dataset_id                  = "1billion_ms_example_dataset"
   project_id                  = module.project.project_id

--- a/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan -out=plan.tfplan -input=false", "-a", "apply -input=false plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-plan.yaml
@@ -23,19 +23,19 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-validate.yaml
@@ -23,18 +23,18 @@ substitutions:
     _LOGS_BUCKET: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -81,7 +81,7 @@ module "project" {
 
 module "one_billion_ms_dataset" {
   source  = "terraform-google-modules/bigquery/google"
-  version = "~> 5.3.0"
+  version = "~> 7.0.0"
 
   dataset_id                  = "1billion_ms_dataset"
   project_id                  = module.project.project_id
@@ -234,7 +234,7 @@ module "project_iam_members" {
 
 module "topic" {
   source  = "terraform-google-modules/pubsub/google"
-  version = "< 6"
+  version = "~> 6.0"
 
   topic      = "topic"
   project_id = module.project.project_id

--- a/templates/tfengine/components/cicd/configs/tf-apply.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-apply.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"}}
 
 timeout: 21600s
 

--- a/templates/tfengine/components/cicd/configs/tf-plan.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-plan.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"}}
 
 timeout: 1200s
 

--- a/templates/tfengine/components/cicd/configs/tf-validate.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-validate.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:e4ef6a7cb46ca110b97eb5fb7134fb9f3720b98560436792a4199c77e739dca0"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:eab4344f007d121e36776d0a435718986fd7664eded83e36973fb4b204b06738"}}
 
 timeout: 600s
 

--- a/templates/tfengine/components/resources/bigquery_datasets/main.tf
+++ b/templates/tfengine/components/resources/bigquery_datasets/main.tf
@@ -15,7 +15,7 @@ limitations under the License. */ -}}
 {{range get . "bigquery_datasets"}}
 module "{{resourceName . "dataset_id"}}" {
   source  = "terraform-google-modules/bigquery/google"
-  version = "~> 5.3.0"
+  version = "~> 7.0.0"
 
   dataset_id = "{{.dataset_id}}"
   project_id = module.project.project_id

--- a/templates/tfengine/components/resources/pubsub_topics/main.tf
+++ b/templates/tfengine/components/resources/pubsub_topics/main.tf
@@ -15,7 +15,7 @@ limitations under the License. */ -}}
 {{range .pubsub_topics}}
 module "{{resourceName . "name"}}" {
   source  = "terraform-google-modules/pubsub/google"
-  version = "< 6"
+  version = "~> 6.0"
 
   topic        = "{{.name}}"
   project_id   = module.project.project_id


### PR DESCRIPTION
Update cloud build container image, pubsub module, and bigquery module

About:
- Update cloud build container image to include Terraform 1.10.5
- Update terraform bigquery module to 7.0.0
- Update terraform pubsub module to 6.0